### PR TITLE
Fixed a couple of bugs

### DIFF
--- a/src/server.coffee
+++ b/src/server.coffee
@@ -8,7 +8,7 @@ ScopedClient = require '../vendor/scoped-http-client/lib'
 class Subscription
   constructor: (data) ->
     Subscription.allowed_keys.forEach (key) =>
-      value  = data.hub[key]
+      value  = data["hub."+key]
       @[key] = value if value?
     @lease_seconds = parseInt(@lease_seconds) || 0
     @bad_params    = null

--- a/test/example_test.coffee
+++ b/test/example_test.coffee
@@ -42,7 +42,7 @@ client = http.createServer (req, resp) ->
     if req.method == 'GET'
       console.log "CLIENT: Receiving verification challenge..." if debugging
       resp.writeHead 200
-      resp.write Url.parse(req.url, true).query.hub.challenge
+      resp.write Url.parse(req.url, true).query["hub.challenge"]
     else
       console.log "CLIENT: Receiving published data..." if debugging
       resp.writeHead 200

--- a/test/verify_test.coffee
+++ b/test/verify_test.coffee
@@ -11,10 +11,10 @@ server = http.createServer (req, resp) ->
   switch req_url.query.testing
     when 'yes'
       resp.writeHead 200
-      resp.write req_url.query.hub.challenge
+      resp.write req_url.query["hub.challenge"]
     when 'no'
       resp.writeHead 300
-      resp.write req_url.query.hub.challenge
+      resp.write req_url.query["hub.challenge"]
     when 'challenge'
       resp.writeHead 200
       resp.write 'nada'


### PR DESCRIPTION
Attributes including a dot need to be requested in array style (`["foo.bar"]`).

I'm not sure if this lib will now work as expected, but the tests will pass.
